### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete multi-character sanitization

### DIFF
--- a/components/utils/format.ts
+++ b/components/utils/format.ts
@@ -113,7 +113,11 @@ export function extractSentence(markdown: string): string {
   });
 
   const content = contentLines.join(' ');
-  const noHtml = content.replace(/<[^>]+>/g, '');
+  const sanitizeHtml = require('sanitize-html');
+  const noHtml = sanitizeHtml(content, {
+    allowedTags: [],
+    allowedAttributes: {}
+  });
   const cleaned = noHtml.replace(/\s+/g, ' ').trim();
 
   const match = cleaned.match(/[^.!?]+[.!?]/);

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "tailwind-merge": "^3.0.2",
     "tm-themes": "^1.10.1",
     "usehooks-ts": "^3.1.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "sanitize-html": "^2.15.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
Potential fix for [https://github.com/Alice39s/kuma-mieru/security/code-scanning/3](https://github.com/Alice39s/kuma-mieru/security/code-scanning/3)

To fix the problem, we should use a well-tested sanitization library that can handle HTML content more effectively. The `sanitize-html` library is a popular choice for this purpose. It will ensure that all unsafe HTML tags and attributes are removed, providing a more robust solution than a custom regular expression.

1. Install the `sanitize-html` library.
2. Replace the custom regular expression used to remove HTML tags with a call to the `sanitize-html` library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
