### PR TITLE
fix(docker-compose.yml): 修正 image 标签为 build 以适应本地构建 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   kuma-mieru:
     # image: ghcr.io/alice39s/kuma-mieru:latest # 还在测试中，建议 build 安装
     # image: kuma-mieru
-    image: .
+    build: .
     container_name: kuma-mieru
     restart: unless-stopped
     ports:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cc085991-dd4f-4cb5-af0a-192b82d4c4dd)
如果使用原来的 `docker-compose.yml` 文件，按照 `README.md` 进行 compose up 会出现如上报错

原因是 compose 从本地构建的话需要把 image 改成 build
估计是 typo 问题

经检验，修正后的 compose file 可以按照 `README.md` 指引正常启动