### PR TITLE
fix(workflows): 更新 Docker 构建工作流，简化构建步骤并支持多平台

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -20,15 +20,8 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            platform: linux/amd64
-          - runner: ubuntu-24.04-arm
-            platform: linux/arm64
-    runs-on: ${{ matrix.runner }}
+  build-and-push:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -42,10 +35,16 @@ jobs:
         run: |
           echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -60,12 +59,12 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.package_version.outputs.version }}
-            type=raw,value=build-${{ github.run_id }}-${{ matrix.platform }}
-            type=sha,prefix=commit-,suffix=-${{ matrix.platform }}
-            type=ref,event=branch,suffix=-${{ matrix.platform }}
-            type=ref,event=pr,suffix=-${{ matrix.platform }}
-            type=semver,pattern={{major}},suffix=-${{ matrix.platform }}
-            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.platform }}
+            type=raw,value=build-${{ github.run_id }}
+            type=sha,prefix=commit
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
           labels: |
             org.opencontainers.image.title=Kuma Mieru
             org.opencontainers.image.description=A 3rd-party Uptime Kuma monitoring dashboard built on Next.js 15, TypeScript and Recharts.
@@ -73,10 +72,10 @@ jobs:
             org.opencontainers.image.licenses=MPL-2.0
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=${{ steps.package_version.outputs.version }}
             type=raw,value=build-${{ github.run_id }}
-            type=sha,prefix=commit
+            type=sha,prefix=commit-
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{major}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   kuma-mieru:
-    # image: ghcr.io/alice39s/kuma-mieru:latest # 还在测试中，建议 build 安装
-    # image: kuma-mieru
-    build: .
+    image: ghcr.io/alice39s/kuma-mieru:latest
+    # 如果遇到问题，请注释上方的 image 行，取消下面的 build 行
+    # build: .
     container_name: kuma-mieru
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   kuma-mieru:
     image: ghcr.io/alice39s/kuma-mieru:latest
-    # 如果遇到问题，请注释上方的 image 行，取消下面的 build 行
+    # 如果遇到问题，请注释上方的 image 行，取消下面的 build 行注释
     # build: .
     container_name: kuma-mieru
     restart: unless-stopped


### PR DESCRIPTION
原先的 workflow 使用了两个 `GitHub Worker`（大概是这么说？）导致产生了两次 `PUSH` 操作
也就是 `arm64` 和 `amd64` 两个 Worker 都 `PUSH` 了一次 latest 标签
导致用户侧在 `docker compose up -d` 的 pull 阶段可能找不到适合自己平台的 image
（因为 PUSH 会覆盖掉上一次一样标签的 PUSH，不论平台差异）

这个 PR 解决了这个问题，你可以在 [这里](https://github.com/AptS-1547/kuma-mieru/pkgs/container/kuma-mieru) 看到由 Github Workflow 构建出来的通用 images.

参考资料: [Multi-platform image with GitHub Actions](https://docs.docker.com/build/ci/github-actions/multi-platform/)

唯一的问题是，因为使用的是 qemu 进行 arm64 模拟，他的构建时间相对较长 (20 min)
但对于本项目来说，应该不会有太大影响

![image](https://github.com/user-attachments/assets/91dde137-897d-4ee9-94dc-11b49ff39542)
最终结果，在同一个 latest / 版本标签下，同时存在两个不同的平台版本