### PR TITLE
Add status page API fallback for preload data

### DIFF
--- a/services/config.server.ts
+++ b/services/config.server.ts
@@ -1,13 +1,88 @@
 import { apiConfig } from '@/config/api';
-import type { GlobalConfig, Maintenance } from '@/types/config';
+import type { GlobalConfig, Maintenance, PreloadData } from '@/types/config';
 import { ConfigError } from '@/utils/errors';
 import { extractPreloadData } from '@/utils/json-processor';
-import { sanitizeJsonString } from '@/utils/json-sanitizer';
+import { sanitizeJsonString, validatePreloadData } from '@/utils/json-sanitizer';
 import * as cheerio from 'cheerio';
 import { cache } from 'react';
 import { ApiDataError, logApiError } from './utils/api-service';
 import { customFetchOptions, ensureUTCTimezone } from './utils/common';
 import { customFetch } from './utils/fetch';
+
+async function fetchPreloadDataFromApi(): Promise<PreloadData> {
+  const apiUrl = new URL(`/api/status-page/${apiConfig.pageId}`, apiConfig.baseUrl);
+
+  const apiResponse = await customFetch(apiUrl.toString(), customFetchOptions);
+
+  if (!apiResponse.ok) {
+    throw new ConfigError(
+      `Failed to fetch status page API: ${apiResponse.status} ${apiResponse.statusText}`,
+    );
+  }
+
+  const rawData = await apiResponse.json();
+
+  if (!validatePreloadData(rawData)) {
+    throw new ConfigError('Status page API returned invalid data structure');
+  }
+
+  return rawData;
+}
+
+async function fetchPreloadDataFromHtml(): Promise<PreloadData> {
+  const htmlResponse = await customFetch(apiConfig.htmlEndpoint, customFetchOptions);
+
+  if (!htmlResponse.ok) {
+    throw new ConfigError(
+      `Failed to get HTML: ${htmlResponse.status} ${htmlResponse.statusText}`,
+    );
+  }
+
+  const html = await htmlResponse.text();
+  const $ = cheerio.load(html);
+
+  // Uptime Kuma version > 1.18.4, use script#preload-data to get preload data
+  // @see https://github.com/louislam/uptime-kuma/commit/6e07ed20816969bfd1c6c06eb518171938312782
+  // & https://github.com/louislam/uptime-kuma/issues/2186#issuecomment-1270471470
+  let preloadScript = $('#preload-data').text();
+
+  if (!preloadScript || preloadScript.trim() === '') {
+    // Uptime Kuma version <= 1.18.4, use script:contains("window.preloadData") to get preload data
+    const scriptWithPreloadData = $('script:contains("window.preloadData")').text();
+
+    if (scriptWithPreloadData) {
+      const match = scriptWithPreloadData.match(/window\.preloadData\s*=\s*({.*});/);
+      if (match && match[1]) {
+        preloadScript = match[1];
+        console.log('Successfully extracted preload data from window.preloadData');
+      } else {
+        console.error('Failed to extract preload data with regex. Script content:', scriptWithPreloadData.slice(0, 200));
+      }
+    }
+  }
+
+  if (!preloadScript || preloadScript.trim() === '') {
+    console.error('HTML response preview:', html.slice(0, 500));
+    console.error('Available script tags:', $('script').map((i, el) => $(el).attr('id') || 'no-id').get());
+    throw new ConfigError('Preload script tag not found or empty');
+  }
+
+  try {
+    const jsonStr = sanitizeJsonString(preloadScript);
+    return extractPreloadData(jsonStr);
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new ConfigError(
+        `JSON parsing failed: ${error.message}\nProcessed data: ${preloadScript.slice(0, 100)}...`,
+        error,
+      );
+    }
+    if (error instanceof ConfigError) {
+      throw error;
+    }
+    throw new ConfigError('Unknown error parsing preload data', error);
+  }
+}
 
 function processMaintenanceData(maintenanceList: Maintenance[]): Maintenance[] {
   return maintenanceList.map((maintenance) => {
@@ -149,60 +224,23 @@ export const getGlobalConfig = cache(async (): Promise<GlobalConfig> => {
 
 export async function getPreloadData() {
   try {
-    const htmlResponse = await customFetch(apiConfig.htmlEndpoint, customFetchOptions);
-
-    if (!htmlResponse.ok) {
-      throw new ConfigError(
-        `Failed to get HTML: ${htmlResponse.status} ${htmlResponse.statusText}`,
-      );
-    }
-
-    const html = await htmlResponse.text();
-    const $ = cheerio.load(html);
-    
-    // Uptime Kuma version > 1.18.4, use script#preload-data to get preload data
-    // @see https://github.com/louislam/uptime-kuma/commit/6e07ed20816969bfd1c6c06eb518171938312782
-    // & https://github.com/louislam/uptime-kuma/issues/2186#issuecomment-1270471470
-    let preloadScript = $('#preload-data').text();
-
-    if (!preloadScript || preloadScript.trim() === '') {
-      // Uptime Kuma version <= 1.18.4, use script:contains("window.preloadData") to get preload data
-      const scriptWithPreloadData = $('script:contains("window.preloadData")').text();
-      
-      if (scriptWithPreloadData) {
-        const match = scriptWithPreloadData.match(/window\.preloadData\s*=\s*({.*});/);
-        if (match && match[1]) {
-          preloadScript = match[1];
-          console.log('Successfully extracted preload data from window.preloadData');
-        } else {
-          console.error('Failed to extract preload data with regex. Script content:', scriptWithPreloadData.slice(0, 200));
-        }
-      }
-    }
-
-    if (!preloadScript || preloadScript.trim() === '') {
-      console.error('HTML response preview:', html.slice(0, 500));
-      console.error('Available script tags:', $('script').map((i, el) => $(el).attr('id') || 'no-id').get());
-      throw new ConfigError('Preload script tag not found or empty');
-    }
-
     try {
-      const jsonStr = sanitizeJsonString(preloadScript);
-      return extractPreloadData(jsonStr);
-    } catch (error) {
-      if (error instanceof SyntaxError) {
-        throw new ConfigError(
-          `JSON parsing failed: ${error.message}\nProcessed data: ${preloadScript.slice(0, 100)}...`,
-          error,
-        );
+      return await fetchPreloadDataFromHtml();
+    } catch (htmlError) {
+      console.error('Failed to extract preload data from HTML source:', htmlError);
+      console.log('Attempting to fetch preload data from status page API fallback...');
+
+      try {
+        return await fetchPreloadDataFromApi();
+      } catch (apiError) {
+        console.error('Status page API fallback failed:', apiError);
+
+        if (apiError instanceof ConfigError) {
+          throw apiError;
+        }
+
+        throw new ConfigError('Failed to fetch preload data from status page API', apiError);
       }
-      if (error instanceof ConfigError) {
-        throw error;
-      }
-      throw new ConfigError(
-        `Failed to parse preload data: ${error instanceof Error ? error.message : 'Unknown error'}`,
-        error,
-      );
     }
   } catch (error) {
     if (error instanceof ConfigError) {
@@ -222,6 +260,7 @@ export async function getPreloadData() {
     });
     throw new ConfigError(
       'Failed to get preload data, please check network connection and server status',
+      error,
     );
   }
 }


### PR DESCRIPTION
## Summary
- add a status page API fetch helper to reuse during config generation when HTML scraping fails
- teach the server-side preload loader to fall back to the JSON API so deployments blocked by WAFs can still hydrate data

## Testing
- bun run lint
- UPTIME_KUMA_BASE_URL=https://uptime.justss.site PAGE_ID=douba bun run build

------
https://chatgpt.com/codex/tasks/task_b_68ed24aadbc48333bd306c9a9e982eee