### PR TITLE
feat(page): Make StatusPageRoute Props type Promise for proper pageId resolution

### DIFF
--- a/app/[pageId]/page.tsx
+++ b/app/[pageId]/page.tsx
@@ -17,12 +17,17 @@ export async function generateStaticParams() {
     .map((pageId) => ({ pageId }));
 }
 
+// 1. 修改 Props 类型定义，params 是 Promise
 export default async function StatusPageRoute({
   params,
 }: {
-  params: { pageId: string };
+  params: Promise<{ pageId: string }>;
 }) {
-  const pageConfig = getConfig(params.pageId);
+  // 2. 必须先 await params
+  const { pageId } = await params;
+
+  // 3. 使用解析出来的 pageId
+  const pageConfig = getConfig(pageId);
 
   if (!pageConfig) {
     notFound();
@@ -36,7 +41,8 @@ export default async function StatusPageRoute({
   return (
     <PageConfigProvider initialConfig={pageConfig}>
       <AppShell footerConfig={footerConfig} pageTabs={pageTabs}>
-        <StatusPage />
+        {/* 4. 建议加上 key，确保切换页面时组件完全重置 */}
+        <StatusPage key={pageId} />
       </AppShell>
     </PageConfigProvider>
   );


### PR DESCRIPTION
修复之前pageid配置多个时，一直显示第一个pageid内容的问题
原因：
1. 从 Next.js 15 开始，动态路由页面（page.tsx）的 params 属性变成了一个 Promise（异步对象），必须先 await 才能读取其中的属性
2. 代码现状：在 app/[pageId]/page.tsx 中，代码依然是直接同步读取 params.pageId
3. 在 config/api.ts 中，getConfig(undefined) 会触发默认逻辑，始终返回 defaultPageId 的配置。这就是为什么点击不同标签 URL 变了，但内容还是第一个页面的原因。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved dynamic page route handling to ensure proper page state updates when navigating between different pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->