### PR TITLE
fix(docker): 在容器启动时添加 docker-init 脚本执行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,4 +109,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
 # 使用 dumb-init 作为 PID 1，正确处理信号
 # 使用 Node.js 运行 standalone 服务器 (缓解 worker_threads napi 兼容性问题)
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-CMD ["sh", "-c", "bun run generate && bun run scripts/docker-init.ts && node server.js"]
+CMD ["sh", "-c", "bun run generate && bun run scripts/docker-init.ts && exec node server.js"]


### PR DESCRIPTION
- 在 CMD 指令中增加 `bun run scripts/docker-init.ts` 执行步骤
- 确保容器启动时完成必要的初始化工作，然后再启动主服务器

<img width="3024" height="1806" alt="Microsoft Edge 2025-12-26 13 40 40" src="https://github.com/user-attachments/assets/54fc41bd-d2eb-41dd-aac8-79745ca2996a" />

在 Dockerfile 的启动命令中添加回 docker-init.ts 脚本

fix #219 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Startup sequence updated to run an additional initialization step before the server launches; the server process now replaces the temporary startup shell for cleaner process handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->