### PR TITLE
fix: handle non-JSON responses in SWR fetcher

### DIFF
--- a/components/utils/swr.ts
+++ b/components/utils/swr.ts
@@ -20,7 +20,14 @@ interface ApiEnvelope {
  */
 const fetcher = async <T>(url: string): Promise<T> => {
   const response = await fetch(url);
-  const data = (await response.json()) as ApiEnvelope & Record<string, unknown>;
+  let data: ApiEnvelope & Record<string, unknown>;
+  try {
+    data = (await response.json()) as ApiEnvelope & Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `HTTP ${response.status}: Failed to parse response as JSON from ${url}`
+    );
+  }
 
   if (!response.ok) {
     const statusText = response.statusText || 'Unknown Status';


### PR DESCRIPTION
## Summary
- Wraps `response.json()` in the SWR fetcher with a try-catch to gracefully handle non-JSON responses (e.g., HTML error pages from proxies, empty 502/504 bodies)
- Throws a descriptive `Error` with HTTP status and URL instead of surfacing a raw `SyntaxError`

## Motivation
When the upstream Uptime Kuma instance returns a non-JSON response (gateway timeout, proxy error page, truncated response), `response.json()` throws an opaque `SyntaxError` that SWR surfaces poorly. This wraps it in a catch to provide actionable error context.

## Test plan
- [ ] Verify normal JSON API responses still parse correctly
- [ ] Simulate a non-JSON response (e.g., HTML 502 page) and confirm the new error message appears instead of `SyntaxError`
- [ ] Confirm SWR error handling displays the improved message in the UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting during data retrieval to display HTTP status and URL details when parsing failures occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->