### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -352,9 +352,9 @@ We welcome contributions! Please review:
 
 <a href="https://github.com/Alice39s/kuma-mieru/stargazers" target="_blank" style="display: block" align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Alice39s/kuma-mieru&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Alice39s/kuma-mieru&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
   </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -351,9 +351,9 @@ Kuma Mieru 设计之初就是为了解决 Uptime Kuma 的不足，所以 v1 暂�
 
 <a href="https://github.com/Alice39s/kuma-mieru/stargazers" target="_blank" style="display: block" align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Alice39s/kuma-mieru&type=Timeline&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Alice39s/kuma-mieru&type=Timeline&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Alice39s/kuma-mieru&type=Timeline" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the GitHub stargazer API no longer allows our data source to work. This change points the chart to the star-history.dera.page endpoint so the chart renders correctly again in both the Chinese and English READMEs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the English and default README files.
  * Added support for dark mode, light mode, and fallback chart images from the updated source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->